### PR TITLE
Mongo index

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ Inject environmental variables appropriately at either buildtime or runtime
 * IPSEITY_PRIVATE_KEY: A private rsa key in ssh format
 ## Optional (defaults)
 * IPSEITY_MONGO_PORT (27017): The port the Mongo server is running on
-* IPSEITY_MONGO_DB (ipseity): The mongo db name to use to store credentials
+* IPSEITY_MONGO_DB (ipseity): The mongo db name to use to store the collection
+* IPSEITY_MONGO_COLLECTION (authentication): The mongo collection which stores credentials
 * IPSEITY_ACCESS_EXP_DELTA (72000): A length of time for access tokens to remain valid, in seconds
 * IPSEITY_REFRESH_EXP_DELTA (2592000): A length of time for refresh tokens to remain valid, in seconds
 * IPSEITY_VERBOSITY (WARN): The verbosity of the logs

--- a/ipseity/blueprint/__init__.py
+++ b/ipseity/blueprint/__init__.py
@@ -334,7 +334,7 @@ def handle_configs(setup_state):
         authentication_client[BLUEPRINT.config.get('MONGO_DB', 'ipseity')]
 
     BLUEPRINT.config['authentication_coll'] = \
-        authentication_db['authentication']
+        authentication_db[BLUEPRINT.config.get("MONGO_COLLECTION", 'authentication')]
 
     BLUEPRINT.config['authentication_coll'].create_index(
         [('user', ASCENDING)],

--- a/ipseity/blueprint/__init__.py
+++ b/ipseity/blueprint/__init__.py
@@ -315,7 +315,7 @@ class RefreshToken(Resource):
             prune_disallowed_tokens(g.json_token['user'])
             return {"success": True}
         else:
-            raise InvalidTokenError()
+            return {"success": False}
 
 
 @BLUEPRINT.record

--- a/tests/test_ipseity.py
+++ b/tests/test_ipseity.py
@@ -4,7 +4,7 @@ from os import environ
 from os import urandom
 from time import sleep
 
-from pymongo import MongoClient
+from pymongo import MongoClient, ASCENDING
 
 import jwt
 
@@ -78,8 +78,13 @@ class Tests(unittest.TestCase):
         # Run a local mongo on 27017 for testing
         # docker run -p 27017:27017 mongo <-- fire one up with docker if required
         self.client = MongoClient('localhost', 27017)
-        ipseity.blueprint.BLUEPRINT.config['authentication_db'] = \
-            self.client['ipseity_test']
+        ipseity.blueprint.BLUEPRINT.config['authentication_coll'] = \
+            self.client['ipseity_test']['authentication']
+        # Mimic index creation which usually happens at bootstrap
+        ipseity.blueprint.BLUEPRINT.config['authentication_coll'].create_index(
+                    [('user', ASCENDING)],
+                    unique=True
+                )
         self.app = ipseity.app.test_client()
 
     def tearDown(self):
@@ -354,6 +359,24 @@ class Tests(unittest.TestCase):
                                       data={'access_token': access_token})
         self.assertEqual(check_response.status_code, 400)
         del ipseity.blueprint.BLUEPRINT.config['ACCESS_EXP_DELTA']
+
+    def test_disallowed_token_pruning(self):
+        pass
+
+    def test_unauthorized_access(self):
+        pass
+
+    def test_malformed_token(self):
+        pass
+
+    def test_delete_nonexistant_user(self):
+        pass
+
+    def test_delete_access_token(self):
+        pass
+
+    def test_delete_nonexistant_refresh_token(self):
+        pass
 
 
 if __name__ == "__main__":

--- a/tests/test_ipseity.py
+++ b/tests/test_ipseity.py
@@ -328,7 +328,7 @@ class Tests(unittest.TestCase):
         self.assertEqual(access_as_refresh_response.status_code, 400)
 
     def test_expired_refresh_token(self):
-        ipseity.blueprint.BLUEPRINT.config['REFRESH_EXP_DELTA'] = 10
+        ipseity.blueprint.BLUEPRINT.config['REFRESH_EXP_DELTA'] = 5
         self.test_make_user()
         # Get an access token
         authentication_response = self.app.get("/auth_user",
@@ -340,43 +340,77 @@ class Tests(unittest.TestCase):
                                               data={'access_token': access_token})
         self.assertEqual(refresh_token_response.status_code, 200)
         refresh_token = refresh_token_response.data.decode()
-        sleep(11)  # Let the refresh token expire
+        sleep(7)  # Let the refresh token expire
         second_authentication_response = self.app.get("/auth_user",
                                                       data={'user': refresh_token})
         self.assertEqual(second_authentication_response.status_code, 400)
         del ipseity.blueprint.BLUEPRINT.config['REFRESH_EXP_DELTA']
 
     def test_expired_access_token(self):
-        ipseity.blueprint.BLUEPRINT.config['ACCESS_EXP_DELTA'] = 10
+        ipseity.blueprint.BLUEPRINT.config['ACCESS_EXP_DELTA'] = 5
         self.test_make_user()
         # Get an access token
         authentication_response = self.app.get("/auth_user",
                                                data={'user': 'foo', 'pass': 'bar'})
         self.assertEqual(authentication_response.status_code, 200)
         access_token = authentication_response.data.decode()
-        sleep(11)
+        sleep(7)
         check_response = self.app.get("/check",
                                       data={'access_token': access_token})
         self.assertEqual(check_response.status_code, 400)
         del ipseity.blueprint.BLUEPRINT.config['ACCESS_EXP_DELTA']
 
     def test_disallowed_token_pruning(self):
+        # TODO
         pass
 
     def test_unauthorized_access(self):
-        pass
+        for x in ("/test", "/refresh_token"):
+            r = self.app.get(x)
+            self.assertEqual(r.status_code, 401)
+        r = self.app.delete("/del_user")
+        self.assertEqual(r.status_code, 401)
+        r = self.app.post("/change_pass")
+        self.assertEqual(r.status_code, 401)
 
     def test_malformed_token(self):
-        pass
-
-    def test_delete_nonexistant_user(self):
-        pass
+        r = self.app.get("/test",
+                         data={"access_token": "abc123"})
+        self.assertEqual(r.status_code, 401)
 
     def test_delete_access_token(self):
-        pass
+        self.test_make_user()
+        # Get an access token
+        authentication_response = self.app.get("/auth_user",
+                                               data={'user': 'foo', 'pass': 'bar'})
+        self.assertEqual(authentication_response.status_code, 200)
+        access_token = authentication_response.data.decode()
+        delete_access_token_response = \
+            self.app.delete(
+                "/refresh_token",
+                data={
+                    "access_token": access_token,
+                    "refresh_token": access_token
+                }
+            )
+        self.assertEqual(delete_access_token_response.status_code, 400)
 
     def test_delete_nonexistant_refresh_token(self):
-        pass
+        self.test_make_user()
+        # Get an access token
+        authentication_response = self.app.get("/auth_user",
+                                               data={'user': 'foo', 'pass': 'bar'})
+        self.assertEqual(authentication_response.status_code, 200)
+        access_token = authentication_response.data.decode()
+        delete_bad_token_response = \
+            self.app.delete(
+                "/refresh_token",
+                data={
+                    "access_token": access_token,
+                    "refresh_token": "abc123"
+                }
+            )
+        self.assertEqual(delete_bad_token_response.status_code, 400)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #3 - using a Mongo index on the user key instead of a query to prevent duplicate user generation, while speeding up all other queries.

Shortens references to the mongo collection in all other code by assigning the collection, rather than the database, to an internal config slot.

Tests for the disallowed token pruning mechanism, as well as several previously uncovered error cases. In certain cases bugfixes for the error cases.