### PR TITLE
Made the test endpoint support optional authentication, returning the…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
     - "pip install -r requirements_dev.txt"
     - "python setup.py install"
 script: 
-    - coverage run --source ipseity -m py.test 
+    - coverage run --source ipseity,flask_jwtlib -m py.test 
     - docker build . -t proj 
     - flake8 --exit-zero
 after_success:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ipseity
 
-v0.3.0
+v0.4.0
 
 [![Build Status](https://travis-ci.org/bnbalsamo/ipseity.svg?branch=master)](https://travis-ci.org/bnbalsamo/ipseity) [![Coverage Status](https://coveralls.io/repos/github/bnbalsamo/ipseity/badge.svg?branch=master)](https://coveralls.io/github/bnbalsamo/ipseity?branch=master)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ipseity
 
-v0.4.0
+v0.4.1
 
 [![Build Status](https://travis-ci.org/bnbalsamo/ipseity.svg?branch=master)](https://travis-ci.org/bnbalsamo/ipseity) [![Coverage Status](https://coveralls.io/repos/github/bnbalsamo/ipseity/badge.svg?branch=master)](https://coveralls.io/github/bnbalsamo/ipseity?branch=master)
 

--- a/ipseity/blueprint/__init__.py
+++ b/ipseity/blueprint/__init__.py
@@ -271,9 +271,12 @@ class CheckToken(Resource):
 
 
 class Test(Resource):
-    @flask_jwtlib.requires_authentication
+    @flask_jwtlib.optional_authentication
     def get(self):
-        return g.json_token
+        if flask_jwtlib.is_authenticated():
+            return {"Authenticated": True, "Token": g.json_token}
+        else:
+            return {"Authenticated": False, "Token": None}
 
 
 class ChangePassword(Resource):

--- a/ipseity/blueprint/__init__.py
+++ b/ipseity/blueprint/__init__.py
@@ -24,7 +24,7 @@ from .exceptions import UserAlreadyExistsError, \
 
 __author__ = "Brian Balsamo"
 __email__ = "brian@brianbalsamo.com"
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 
 BLUEPRINT = Blueprint('ipseity', __name__)

--- a/ipseity/blueprint/__init__.py
+++ b/ipseity/blueprint/__init__.py
@@ -24,7 +24,7 @@ from .exceptions import UserAlreadyExistsError, \
 
 __author__ = "Brian Balsamo"
 __email__ = "brian@brianbalsamo.com"
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 
 BLUEPRINT = Blueprint('ipseity', __name__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.4.0
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 setup(
     name="ipseity",
     description="An authentication API",
-    version="0.3.0",
+    version="0.4.0",
     long_description=readme(),
     author="Brian Balsamo",
     author_email="brian@brianbalsamo.com",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 setup(
     name="ipseity",
     description="An authentication API",
-    version="0.4.0",
+    version="0.4.1",
     long_description=readme(),
     author="Brian Balsamo",
     author_email="brian@brianbalsamo.com",


### PR DESCRIPTION
… authentication result in the body. Added flask_jwtlib testing to the coverage metrics.

This merge should also include the bump to version 0.1.0 of bnbalsamo/flask_jwtlib